### PR TITLE
Bugfix

### DIFF
--- a/src/json/training_params.example.json
+++ b/src/json/training_params.example.json
@@ -14,7 +14,6 @@
     "d_beta_min": 0.5,
     "d_beta_max": 0.999,
     "sample_size": 64,
-    "label_smoothing": 0.9,
     "features_g": 64,
     "features_d": 64,
     "channels_img": 3,


### PR DESCRIPTION
feat: remove label_smooth from training_params file because don't usefull in BEGAN